### PR TITLE
ルーティング関連の修正

### DIFF
--- a/app/Plugin/ExamplePlugin/Entity/ExamplePayment.php
+++ b/app/Plugin/ExamplePlugin/Entity/ExamplePayment.php
@@ -14,7 +14,7 @@ use Doctrine\ORM\Mapping\Table;
 class ExamplePayment extends \Eccube\Entity\Payment
 {
     /**
-     * @Column(name="use_paypal", type="smallint")
+     * @Column(name="use_paypal", type="smallint", nullable=true, options="default":0})
      */
     public $usePayPal = 0;
 }

--- a/app/Plugin/ExamplePlugin/Resource/doctrine/migrations/Version20170222080706.php
+++ b/app/Plugin/ExamplePlugin/Resource/doctrine/migrations/Version20170222080706.php
@@ -17,7 +17,9 @@ class Version20170222080706 extends AbstractMigration
     {
         $Table = $schema->getTable('dtb_payment');
         if (!$Table->hasColumn('use_paypal')) {
-            $Table->addColumn('use_paypal','smallint');
+            $Table->addColumn('use_paypal','smallint', [
+                'default' => 0
+            ]);
         }
     }
 

--- a/app/Plugin/ExamplePlugin/Resource/doctrine/migrations/Version20170222080706.php
+++ b/app/Plugin/ExamplePlugin/Resource/doctrine/migrations/Version20170222080706.php
@@ -18,6 +18,7 @@ class Version20170222080706 extends AbstractMigration
         $Table = $schema->getTable('dtb_payment');
         if (!$Table->hasColumn('use_paypal')) {
             $Table->addColumn('use_paypal','smallint', [
+                'notnul' => false,
                 'default' => 0
             ]);
         }

--- a/src/Eccube/Application.php
+++ b/src/Eccube/Application.php
@@ -155,7 +155,6 @@ class Application extends \Silex\Application
             'http_cache.cache_dir' => __DIR__.'/../../app/cache/http/',
         ));
         $this->register(new \Silex\Provider\HttpFragmentServiceProvider());
-        $this->register(new \Silex\Provider\RoutingServiceProvider());
         $this->register(new \Silex\Provider\FormServiceProvider());
         $this->register(new \Silex\Provider\SerializerServiceProvider());
         $this->register(new \Silex\Provider\ValidatorServiceProvider());

--- a/src/Eccube/Application.php
+++ b/src/Eccube/Application.php
@@ -225,6 +225,8 @@ class Application extends \Silex\Application
         $this->mount('/'.trim($this['config']['admin_route'], '/').'/', new ControllerProvider\AdminControllerProvider());
         Request::enableHttpMethodParameterOverride(); // PUTやDELETEできるようにする
 
+        // ルーティングの設定
+        // TODO EccubeRoutingServiceProviderに移植する.
         $app = $this;
         $this['eccube.router'] = $this->protect(function($resoure, $cachePrefix) use ($app) {
             $options = [
@@ -252,6 +254,7 @@ class Application extends \Silex\Application
         };
 
         $this['eccube.routers.plugin'] = function ($app) {
+            // TODO 有効なプラグインを対象とする必要がある.
             $dirs = Finder::create()
                 ->in($app['config']['root_dir'].'/app/Plugin')
                 ->name('Controller')

--- a/src/Eccube/Application.php
+++ b/src/Eccube/Application.php
@@ -33,6 +33,8 @@ use Sergiors\Silex\Provider\DoctrineCacheServiceProvider;
 use Sergiors\Silex\Provider\RoutingServiceProvider;
 use Sergiors\Silex\Provider\SensioFrameworkExtraServiceProvider;
 use Sergiors\Silex\Provider\TemplatingServiceProvider;
+use Sergiors\Silex\Routing\ChainUrlGenerator;
+use Sergiors\Silex\Routing\ChainUrlMatcher;
 use Symfony\Component\EventDispatcher\EventDispatcher;
 use Symfony\Component\Finder\Finder;
 use Symfony\Component\HttpFoundation\Request;
@@ -197,14 +199,15 @@ class Application extends \Silex\Application
         $this->initSecurity();
 
         $this->register(new \Sergiors\Silex\Provider\RoutingServiceProvider(), [
-            'routing.cache_dir' => __DIR__.'/../../app/cache/routing'
+            'routing.cache_dir' => $this['debug'] ? null : __DIR__.'/../../app/cache/routing'
         ]);
         $this->register(new \Sergiors\Silex\Provider\DoctrineCacheServiceProvider());
         $this->register(new \Sergiors\Silex\Provider\TemplatingServiceProvider());
         $this->register(new \Sergiors\Silex\Provider\AnnotationsServiceProvider(), [
+            'annotations.debug' => $this['debug'],
             'annotations.options' => [
-                'cache_driver' => 'filesystem',
-                'cache_dir' => __DIR__.'/../../app/cache/annotation'
+                'cache_driver' => $this['debug'] ? 'array' : 'filesystem',
+                'cache_dir' => $this['debug'] ? null : __DIR__.'/../../app/cache/annotation'
             ]
         ]);
         $this->register(new \Sergiors\Silex\Provider\SensioFrameworkExtraServiceProvider(), [
@@ -222,31 +225,77 @@ class Application extends \Silex\Application
         $this->mount('/'.trim($this['config']['admin_route'], '/').'/', new ControllerProvider\AdminControllerProvider());
         Request::enableHttpMethodParameterOverride(); // PUTやDELETEできるようにする
 
-        $this->extend('routes', function (\Symfony\Component\Routing\RouteCollection $routes, \Silex\Application $app) {
-            $loader = $this['sensio_framework_extra.routing.loader.annot_dir'];
+        $app = $this;
+        $this['eccube.router'] = $this->protect(function($resoure, $cachePrefix) use ($app) {
+            $options = [
+                'debug' => $app['debug'],
+                'cache_dir' => $app['routing.cache_dir'],
+                'matcher_base_class' => $app['request_matcher_class'],
+                'matcher_class' => $app['request_matcher_class'],
+                'matcher_cache_class' => $cachePrefix.'UrlMatcher',
+                'generator_cache_class' => $cachePrefix.'UrlGenerator'
+            ];
+            return new \Symfony\Component\Routing\Router(
+                $app['routing.loader'],
+                $resoure,
+                $options,
+                $app['request_context'],
+                $app['logger']
+            );
+        });
 
-            // コントローラのルーティングをロード
-            $collection = $loader->import(__DIR__.'/Controller', 'annotation');
-            $routes->addCollection($collection);
+        $this['eccube.router.origin'] = function ($app) {
+            $resource = __DIR__.'/Controller';
+            $cachePrefix = 'Origin';
 
-            // プラグイン用のルーティングをロード
-            // XXX 有効なプラグインのみ対象としたい
+            return $app['eccube.router']($resource, $cachePrefix);
+        };
+
+        $this['eccube.routers.plugin'] = function ($app) {
             $dirs = Finder::create()
-                ->in($this['config']['root_dir'].'/app/Plugin')
+                ->in($app['config']['root_dir'].'/app/Plugin')
                 ->name('Controller')
                 ->directories();
 
+            $routers = [];
             foreach ($dirs as $dir) {
-                // プラグイン用のルーティングをロード
-                $collection = $loader->import($dir->getRealPath(), 'annotation');
-                $routes->addCollection($collection);
+                $realPath = $dir->getRealPath();
+                $plugiCode = basename(dirname($realPath));
+                $routers[] = $app['eccube.router']($realPath, 'Plugin'.$plugiCode);
             }
 
-            // 拡張用のルーティングをロード
-            $collection = $loader->import($this['config']['root_dir'].'/app/Eccube/Controller', 'annotation');
-            $routes->addCollection($collection);
+            return $routers;
+        };
 
-            return $routes;
+        $this['eccube.router.extend'] = function ($app) {
+            $resource = $app['config']['root_dir'].'/app/Eccube/Controller';
+            $cachePrefix = 'Extend';
+
+            return $app['eccube.router']($resource, $cachePrefix);
+        };
+
+        $this->extend('request_matcher', function ($matcher, $app) {
+            $matchers = [];
+            $matchers[] = $app['eccube.router.extend'];
+            foreach ($app['eccube.routers.plugin'] as $router) {
+                $matchers[] = $router;
+            };
+            $matchers[] = $app['eccube.router.origin'];
+            $matchers[] = $matcher;
+
+            return new ChainUrlMatcher($matchers, $app['request_context']);
+        });
+
+        $this->extend('url_generator', function ($generator, $app) {
+            $generators = [];
+            $generators[] = $app['eccube.router.extend'];
+            foreach ($app['eccube.routers.plugin'] as $router) {
+                $generators[] = $router;
+            };
+            $generators[] = $app['eccube.router.origin'];
+            $generators[] = $generator;
+
+            return new ChainUrlGenerator($generators, $app['request_context']);
         });
 
         // init http cache

--- a/src/Eccube/Application.php
+++ b/src/Eccube/Application.php
@@ -260,8 +260,8 @@ class Application extends \Silex\Application
             $routers = [];
             foreach ($dirs as $dir) {
                 $realPath = $dir->getRealPath();
-                $plugiCode = basename(dirname($realPath));
-                $routers[] = $app['eccube.router']($realPath, 'Plugin'.$plugiCode);
+                $pluginCode = basename(dirname($realPath));
+                $routers[] = $app['eccube.router']($realPath, 'Plugin'.$pluginCode);
             }
 
             return $routers;


### PR DESCRIPTION
- デバッグ時はアノテーション/ルーティングをキャッシュしないように修正
- ルーティングが以下の順に読まれるように修正
  - 拡張コントローラ
  - プラグイン
  - 本体のコントローラ
  - 本体のコントローラプロバイダ
- サンプルプラグインのテーブル作成の定義を修正