### PR TITLE
TransactionListenerを有効に

### DIFF
--- a/src/Eccube/ServiceProvider/EccubeServiceProvider.php
+++ b/src/Eccube/ServiceProvider/EccubeServiceProvider.php
@@ -24,14 +24,15 @@
 
 namespace Eccube\ServiceProvider;
 
+use Eccube\EventListener\TransactionListener;
 use Eccube\Service\OrderHelper;
 use Pimple\Container;
 use Pimple\ServiceProviderInterface;
-use Silex\Api\BootableProviderInterface;
-use Silex\Application;
+use Silex\Api\EventListenerProviderInterface;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\HttpFoundation\ParameterBag;
 
-class EccubeServiceProvider implements ServiceProviderInterface, BootableProviderInterface
+class EccubeServiceProvider implements ServiceProviderInterface, EventListenerProviderInterface
 {
     /**
      * Registers services on the given app.
@@ -424,17 +425,8 @@ class EccubeServiceProvider implements ServiceProviderInterface, BootableProvide
         });
     }
 
-    /**
-     * Bootstraps the application.
-     *
-     * This method is called after all services are registered
-     * and should be used for "dynamic" configuration (whenever
-     * a service must be requested).
-     */
-    public function boot(Application $app)
+    public function subscribe(Container $app, EventDispatcherInterface $dispatcher)
     {
-        // add transaction listener
-        // FIXME TransactionListener::onKernelTerminate が動作しないため暫定的に無効
-        // $app['dispatcher']->addSubscriber(new \Eccube\EventListener\TransactionListener($app));
+        $dispatcher->addSubscriber(new TransactionListener($app));
     }
 }

--- a/tests/Eccube/Tests/EccubeTestCase.php
+++ b/tests/Eccube/Tests/EccubeTestCase.php
@@ -53,8 +53,10 @@ abstract class EccubeTestCase extends WebTestCase
         }
 
         // XXX PHP5.5/5.6でSegmentation Faultが発生するため
-        //$this->cleanUpProperties();
-        //$this->app = null;
+        if (version_compare(PHP_VERSION, '7.0.0', '>=')) {
+            $this->cleanUpProperties();
+            $this->app = null;
+        }
 
         \Eccube\Application::clearInstance();
     }

--- a/tests/Eccube/Tests/EccubeTestCase.php
+++ b/tests/Eccube/Tests/EccubeTestCase.php
@@ -53,7 +53,7 @@ abstract class EccubeTestCase extends WebTestCase
         }
 
         // XXX PHP5.5/5.6でSegmentation Faultが発生するため
-        if (version_compare(PHP_VERSION, '7.0.0', '>=')) {
+        if (PHP_VERSION_ID >= 70000) {
             $this->cleanUpProperties();
             $this->app = null;
         }


### PR DESCRIPTION
- BootableProviderInterface から EventListenerProviderInterface に変更
- php7以上の場合は、cleanupPropertyを実行するように修正

TransactionListener自体は動いているようです。
以前、購入完了時にエラーがでたのはおそらく他の要因かと思われます。