### PR TITLE
TransactionListenerが動作しない問題の対応

### DIFF
--- a/src/Eccube/Resource/config/mail.yml.dist
+++ b/src/Eccube/Resource/config/mail.yml.dist
@@ -7,3 +7,4 @@ mail:
     encryption: null
     auth_mode: null
     charset_iso_2022_jp: false
+    spool: false

--- a/src/Eccube/ServiceProvider/EccubeServiceProvider.php
+++ b/src/Eccube/ServiceProvider/EccubeServiceProvider.php
@@ -427,7 +427,6 @@ class EccubeServiceProvider implements ServiceProviderInterface, EventListenerPr
 
     public function subscribe(Container $app, EventDispatcherInterface $dispatcher)
     {
-        // FIXME TransactionListener::onKernelTerminate が動作しないため暫定的に無効
-        // $dispatcher->addSubscriber(new TransactionListener($app));
+        $dispatcher->addSubscriber(new TransactionListener($app));
     }
 }


### PR DESCRIPTION
- TerminateイベントがSwiftMailer->TransactionListenerの順に実行されるため、SwiftMailerが失敗するとTransactionListenerのコミット処理が走らない
- SwiftMailerのspoolを無効にし、$app[‘mailer’]->send()呼び出し時にメール送信処理を行うように修正