### PR TITLE
`style_class` の初期値の設定と未定義の場合に 'ec-select' を設定する処理を追加

### DIFF
--- a/src/Eccube/Form/Extension/DoctrineOrmExtension.php
+++ b/src/Eccube/Form/Extension/DoctrineOrmExtension.php
@@ -103,6 +103,10 @@ class DoctrineOrmExtension extends AbstractTypeExtension
             $options['form_theme'] = null;
         }
 
+        if (!array_key_exists('style_class', $options)) {
+            $options['style_class'] = 'ec-select';
+        }
+
         $view->vars['eccube_form_options'] = $options;
     }
 
@@ -113,6 +117,7 @@ class DoctrineOrmExtension extends AbstractTypeExtension
             [
                 'auto_render' => false,
                 'form_theme' => null,
+                'style_class' => 'ec-select',
             ]
         );
     }


### PR DESCRIPTION
## 概要(Overview・Refs Issue)
FormExtensionで `'auto_render' => true` だけ指定してFormを追加すると `style_class` 未定義のエラーとなりました。
`style_class` の初期値の設定と未定義の場合に 'ec-select' を設定する処理を追加しました。


