### PR TITLE
composer require ext-intl:*

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     "minimum-stability": "stable",
     "require": {
         "php": "^7.1.3",
-        "ext-intl": "^1.1",
+        "ext-intl": "*",
         "ext-mbstring": "*",
         "composer/ca-bundle": "^1.1",
         "composer/composer": "^1.6",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "dcc92aaca121508dd151dee97c178d06",
+    "content-hash": "88f0068d67d51e28078cf25ca541e669",
     "packages": [
         {
             "name": "composer/ca-bundle",
@@ -9632,7 +9632,7 @@
     "prefer-lowest": false,
     "platform": {
         "php": "^7.1.3",
-        "ext-intl": "^1.1",
+        "ext-intl": "*",
         "ext-mbstring": "*"
     },
     "platform-dev": [],

--- a/symfony.lock
+++ b/symfony.lock
@@ -260,6 +260,9 @@
     "psr/simple-cache": {
         "version": "1.0.0"
     },
+    "ralouphie/getallheaders": {
+        "version": "2.0.5"
+    },
     "sebastian/code-unit-reverse-lookup": {
         "version": "1.0.1"
     },


### PR DESCRIPTION
`The requested PHP extension ext-intl ^1.1 has the wrong version (7.3.2) installed. Install or enable PHP's intl extension.`

ext-intlも更新する必要があったので、`composer require ext-intl:*`しています。


