### PR TITLE
Dockerfile - 443ポートでSSL通信ができるように設定を追加

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ RUN /bin/rm /etc/apt/sources.list
 RUN apt-get update && apt-get install -y \
         curl apt-utils apt-transport-https debconf-utils gcc build-essential \
         zlib1g-dev git gnupg2 unzip libfreetype6-dev libjpeg62-turbo-dev \
-        libpng-dev libzip-dev libicu-dev vim git \
+        libpng-dev libzip-dev libicu-dev vim git ssl-cert \
         && docker-php-ext-install -j$(nproc) zip gd mysqli pdo_mysql opcache intl \
         && rm -rf /var/lib/apt/lists/*
 
@@ -31,6 +31,11 @@ RUN sed -ri -e 's!/var/www/!${APACHE_DOCUMENT_ROOT}!g' /etc/apache2/apache2.conf
 
 RUN a2enmod rewrite
 RUN a2enmod headers
+
+# Enable SSL
+RUN a2enmod ssl
+RUN ln -s /etc/apache2/sites-available/default-ssl.conf /etc/apache2/sites-enabled/default-ssl.conf
+EXPOSE 443
 
 # Use the default production configuration
 RUN mv "$PHP_INI_DIR/php.ini-production" "$PHP_INI_DIR/php.ini"


### PR DESCRIPTION
https://github.com/EC-CUBE/php-ext-apache/blob/master/7.1/Dockerfile
を参考にしながら443ポートでSSL通信できるようにしてみました。
どんなでしょうか？

## テスト
イメージのビルド後 `docker run --name ec-cube -d -p "18080:80" -p "8443:443" eccube4-php-apache` で起動してhttpsで表示できることを確認しています。