### PR TITLE
コマンドのキャッシュクリア処理を別プロセスで実行

### DIFF
--- a/src/Eccube/Command/PluginCommandTrait.php
+++ b/src/Eccube/Command/PluginCommandTrait.php
@@ -15,9 +15,9 @@ namespace Eccube\Command;
 
 use Eccube\Repository\PluginRepository;
 use Eccube\Service\PluginService;
-use Symfony\Component\Console\Command\Command;
-use Symfony\Component\Console\Input\ArrayInput;
 use Symfony\Component\Console\Style\SymfonyStyle;
+use Symfony\Component\Process\Exception\ProcessFailedException;
+use Symfony\Component\Process\Process;
 
 trait PluginCommandTrait
 {
@@ -51,14 +51,13 @@ trait PluginCommandTrait
 
     protected function clearCache(SymfonyStyle $io)
     {
+        $command = 'cache:clear --no-warmup';
         try {
-            /* @var Command $command */
-            $command = $this->getApplication()->get('cache:clear');
-            $command->run(new ArrayInput([
-                'command' => 'cache:clear',
-                '--no-warmup' => true,
-            ]), $io);
-        } catch (\Exception $e) {
+            $io->text(sprintf('<info>Run %s</info>...', $command));
+            $process = new Process('bin/console '.$command);
+            $process->mustRun();
+            $io->text($process->getOutput());
+        } catch (ProcessFailedException $e) {
             $io->error($e->getMessage());
         }
     }


### PR DESCRIPTION
## 概要(Overview・Refs Issue)

関連 https://github.com/EC-CUBE/ec-cube/pull/4787

prodでプラグイン有効化後に手動でキャッシュをクリアしないと有効になりませんでした。
コマンドのキャッシュクリア処理を別プロセスで実行するように修正しました。

こちらは4.0系では発生していませんでした。
キャッシュがクリアできない要因はわかっていませんが、Symfony4.4での仕様変更の影響かなと思っています。

## 方針(Policy)

## 実装に関する補足(Appendix)

## テスト（Test)

## 相談（Discussion）



