### PR TITLE
初期インストールプラグインがない場合にプラグイン有効化の文言を非表示 / インストール完了後のリダイレクト先をログイン画面に修正

### DIFF
--- a/src/Eccube/Controller/InstallPluginController.php
+++ b/src/Eccube/Controller/InstallPluginController.php
@@ -145,7 +145,7 @@ class InstallPluginController extends InstallController
             unlink($transaction);
         }
 
-        return $this->redirectToRoute('admin_homepage');
+        return $this->redirectToRoute('admin_login');
     }
 
     /**

--- a/src/Eccube/Resource/template/install/complete.twig
+++ b/src/Eccube/Resource/template/install/complete.twig
@@ -26,6 +26,10 @@ file that was distributed with this source code.
          $.get({ url: '{{ url('install_plugins') }}' },
                function (data) {
                    $('#plugins').children().remove();
+                   if (data.length === 0) {
+                       $('#plugins_switch').hide();
+                       return;
+                   }
                    data.forEach(function (plugin) {
                        var content = $(plugin_content).clone();
                        var url = '{{ url('install_plugin_enable', { 'code': '__code__' }) }}';
@@ -76,7 +80,7 @@ file that was distributed with this source code.
                       btn.toggleClass('active');
                       btn.toggleClass('btn-success');
                       btn.toggleClass('btn-default');
-                      console.log(jqXHR);;
+                      console.log(jqXHR);
                       console.log(textStatus);
                       console.log(errorThrown);
                       if (jqXHR.status == 404) {
@@ -99,7 +103,7 @@ file that was distributed with this source code.
                 <div class="page-header">
                     <h1>{{ 'install.completed'|trans }}</h1>
                 </div>
-                <div class="column">
+                <div class="column" id="plugins_switch">
                     <h2>以下のプラグインは有効化してすぐにご利用可能です</h2>
                     <p><small>あとから管理画面→オーナーズストア→プラグイン一覧より有効化も可能です</small></p>
                     <div class="card-body p-0">


### PR DESCRIPTION
## 概要(Overview・Refs Issue)

refs https://github.com/EC-CUBE/ec-cube/pull/5074

- 初期インストールプラグインがない場合にプラグイン有効化の文言を非表示
- インストール完了後のリダイレクト先をログイン画面に修正

## テスト（Test)

ローカルでの動作確認を実施

## 相談（Discussion）

## マイナーバージョン互換性保持のための制限事項チェックリスト

- [x] 既存機能の仕様変更
- [x] フックポイントの呼び出しタイミングの変更
- [x] フックポイントのパラメータの削除・データ型の変更
- [x] twigファイルに渡しているパラメータの削除・データ型の変更
- [x] Serviceクラスの公開関数の、引数の削除・データ型の変更
- [x] 入出力ファイル(CSVなど)のフォーマット変更

## レビュワー確認項目

- [ ] 動作確認
- [ ] コードレビュー
- [ ] E2E/Unit テスト確認(テストの追加・変更が必要かどうか)
- [ ] 互換性が保持されているか
- [ ] セキュリティ上の問題がないか
