### PR TITLE
feat: トップページに売上上位5商品を表示

### DIFF
--- a/src/Eccube/Controller/TopController.php
+++ b/src/Eccube/Controller/TopController.php
@@ -13,17 +13,38 @@
 
 namespace Eccube\Controller;
 
+use Eccube\Repository\ProductRepository;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Template;
 use Symfony\Component\Routing\Annotation\Route;
 
 class TopController extends AbstractController
 {
     /**
+     * @var ProductRepository
+     */
+    protected $productRepository;
+
+    /**
+     * TopController constructor.
+     *
+     * @param ProductRepository $productRepository
+     */
+    public function __construct(ProductRepository $productRepository)
+    {
+        $this->productRepository = $productRepository;
+    }
+
+    /**
      * @Route("/", name="homepage", methods={"GET"})
      * @Template("index.twig")
      */
     public function index()
     {
-        return [];
+        // 売上上位5商品を取得
+        $bestSellingProducts = $this->productRepository->findBestSellingProducts(5);
+
+        return [
+            'best_selling_products' => $bestSellingProducts,
+        ];
     }
 }

--- a/src/Eccube/Repository/ProductRepository.php
+++ b/src/Eccube/Repository/ProductRepository.php
@@ -412,4 +412,53 @@ class ProductRepository extends AbstractRepository
 
         return $this->queries->customize(QueryKey::PRODUCT_SEARCH_ADMIN, $qb, $searchData);
     }
+
+    /**
+     * 売上上位商品を取得する
+     *
+     * @param int $limit 取得する商品数
+     * @param \DateTime|null $startDate 期間の開始日時（nullの場合は全期間）
+     * @param \DateTime|null $endDate 期間の終了日時（nullの場合は全期間）
+     * @return array 売上上位の商品配列
+     */
+    public function findBestSellingProducts($limit = 5, $startDate = null, $endDate = null)
+    {
+        $qb = $this->createQueryBuilder('p');
+        $qb->select('p, SUM(oi.quantity) as total_quantity')
+            ->innerJoin(\Eccube\Entity\OrderItem::class, 'oi', 'WITH', 'oi.Product = p')
+            ->innerJoin('oi.Order', 'o')
+            ->where('p.Status = :status')
+            ->andWhere('oi.OrderItemType = :itemType')
+            // 注文取消し、返品を除外
+            ->andWhere('o.OrderStatus NOT IN (:excludeStatus)')
+            ->setParameter('status', ProductStatus::DISPLAY_SHOW)
+            ->setParameter('itemType', \Eccube\Entity\Master\OrderItemType::PRODUCT)
+            ->setParameter('excludeStatus', [
+                \Eccube\Entity\Master\OrderStatus::CANCEL,
+                \Eccube\Entity\Master\OrderStatus::RETURNED
+            ])
+            ->groupBy('p.id')
+            ->orderBy('total_quantity', 'DESC')
+            ->setMaxResults($limit);
+
+        // 期間指定がある場合
+        if ($startDate !== null) {
+            $qb->andWhere('o.order_date >= :startDate')
+                ->setParameter('startDate', $startDate);
+        }
+        if ($endDate !== null) {
+            $qb->andWhere('o.order_date <= :endDate')
+                ->setParameter('endDate', $endDate);
+        }
+
+        $results = $qb->getQuery()->getResult();
+        
+        // 商品エンティティのみを返す
+        $products = [];
+        foreach ($results as $result) {
+            $products[] = $result[0]; // 商品エンティティは配列の最初の要素
+        }
+        
+        return $products;
+    }
 }

--- a/src/Eccube/Resource/locale/messages.en.yaml
+++ b/src/Eccube/Resource/locale/messages.en.yaml
@@ -120,6 +120,8 @@ front.block.eyecatch.view_list: See all
 front.block.new_item.title__en: NEW ITEMS
 front.block.new_item.title__ja: New Items
 front.block.new_item.more: More
+front.block.best_sellers.title__en: BEST SELLERS
+front.block.best_sellers.title__ja: Best Sellers
 # Deprecated https://github.com/EC-CUBE/ec-cube/pull/4920
 front.block.new_item.item_1_name: "Colorful Gelato: 'CUBE'"
 front.block.new_item.item_1_price: $1,200 (tax incl.)

--- a/src/Eccube/Resource/locale/messages.ja.yaml
+++ b/src/Eccube/Resource/locale/messages.ja.yaml
@@ -120,6 +120,8 @@ front.block.eyecatch.view_list: 一覧を見る
 front.block.new_item.title__en: NEW ITEM
 front.block.new_item.title__ja: 新着商品
 front.block.new_item.more: more
+front.block.best_sellers.title__en: BEST SELLERS
+front.block.best_sellers.title__ja: 売上ランキング
 # Deprecated https://github.com/EC-CUBE/ec-cube/pull/4920
 front.block.new_item.item_1_name: 彩のジェラート"CUBE"
 front.block.new_item.item_1_price: ￥1,200(税込)

--- a/src/Eccube/Resource/template/default/index.twig
+++ b/src/Eccube/Resource/template/default/index.twig
@@ -111,4 +111,40 @@ file that was distributed with this source code.
             <div class="item slick-slide"><img src="{{ asset('assets/img/top/img_hero_pc03.jpg') }}"></div>
         </div>
     </div>
+
+    {# 売上上位商品セクション #}
+    {% if best_selling_products|length > 0 %}
+    <div class="ec-role">
+        <div class="ec-newItemRole">
+            <div class="ec-newItemRole__list">
+                <div class="ec-newItemRole__listItem">
+                    <div class="ec-newItemRole__listItemHeading ec-secHeading--tandem">
+                        <span class="ec-secHeading__en">{{ 'front.block.best_sellers.title__en'|trans }}</span>
+                        <span class="ec-secHeading__line"></span>
+                        <span class="ec-secHeading__ja">{{ 'front.block.best_sellers.title__ja'|trans }}</span>
+                    </div>
+                </div>
+                {% for Product in best_selling_products %}
+                <div class="ec-newItemRole__listItem">
+                    <a href="{{ url('product_detail', {'id': Product.id}) }}">
+                        <img class="ec-newItemRole__listItemThumbnail" src="{{ asset(Product.main_list_image|no_image_product, 'save_image') }}" alt="{{ Product.name }}" {% if loop.index > 5 %} loading="lazy"{% endif %}>
+                        <p class="ec-newItemRole__listItemTitle">{{ Product.name }}</p>
+                        <p class="ec-newItemRole__listItemPrice">
+                            {% if Product.hasProductClass %}
+                                {% if Product.getPrice02Min == Product.getPrice02Max %}
+                                    {{ Product.getPrice02IncTaxMin|price }}
+                                {% else %}
+                                    {{ Product.getPrice02IncTaxMin|price }} ～ {{ Product.getPrice02IncTaxMax|price }}
+                                {% endif %}
+                            {% else %}
+                                {{ Product.getPrice02IncTaxMin|price }}
+                            {% endif %}
+                        </p>
+                    </a>
+                </div>
+                {% endfor %}
+            </div>
+        </div>
+    </div>
+    {% endif %}
 {% endblock %}


### PR DESCRIPTION
### 概要

トップページに売上上位5商品を表示する機能を実装しました。

### 変更内容

- ProductRepositoryにfindBestSellingProductsメソッドを追加
  - 売上数量に基づいて商品をランキング化
  - キャンセルや返品された注文を除外
  - 期間指定可能（デフォルトは全期間）
- TopControllerを更新してベストセラー商品を取得
- index.twigテンプレートに売上ランキングセクションを追加
  - EC-CUBEの標準的なデザインパターンに従った実装
  - レスポンシブ対応
- 日本語・英語の翻訳を追加

Closes #66

Generated with [Claude Code](https://claude.ai/code)