### PR TITLE
test: bcround CI 検証（composer キャッシュ無効・fresh install）

### DIFF
--- a/.github/actions/composer/action.yml
+++ b/.github/actions/composer/action.yml
@@ -1,15 +1,6 @@
 runs:
   using: "Composite"
   steps:
-    - name: Get Composer Cache Directory
-      uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306  # v5
-      id: composer-cache
-      with:
-        path: ${{ github.workspace }}/vendor
-        key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
-        restore-keys: |
-          ${{ runner.os }}-composer-
-
     - name: composer install
       run: composer install --dev --no-interaction -o --apcu-autoloader
       shell: bash

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -82,6 +82,7 @@ jobs:
           php-version: ${{ matrix.php }}
           github-token: ''
           extensions: :xdebug, redis
+          ini-values: opcache.enable=0, opcache.enable_cli=0
       - name: Initialize Composer
         uses: ./.github/actions/composer
 

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -86,6 +86,22 @@ jobs:
       - name: Initialize Composer
         uses: ./.github/actions/composer
 
+      - name: Diagnose bcround
+        run: |
+          php -r '
+            require "vendor/autoload.php";
+            echo "PHP=".PHP_VERSION."\n";
+            echo "bcmath=".(extension_loaded("bcmath")?1:0)." apcu=".(extension_loaded("apcu")?1:0)." opcache=".(extension_loaded("Zend OPcache")?1:0)."\n";
+            echo "Php84::bcround method_exists=".(method_exists("Symfony\\Polyfill\\Php84\\Php84","bcround")?1:0)."\n";
+            echo "RoundingMode=".((class_exists("RoundingMode")||enum_exists("RoundingMode"))?1:0)."\n";
+            $rm = new ReflectionClass("Symfony\\Polyfill\\Php84\\Php84");
+            echo "Php84 file=".$rm->getFileName()."\n";
+            echo "Php84 methods=".implode(",", array_map(function($m){return $m->name;}, $rm->getMethods()))."\n";
+            $rf = new ReflectionFunction("bcround");
+            echo "global bcround=".$rf->getFileName().":".$rf->getStartLine()."\n";
+            echo "bcround(2.5)=".@bcround("2.5")."\n";
+          '
+
       - name: Generate ECCUBE_AUTH_MAGIC
         run: echo "ECCUBE_AUTH_MAGIC=$(openssl rand -hex 32)" >> $GITHUB_ENV
 

--- a/src/Eccube/Rector/CodingStyle/AttributeArgumentsOrderRector.php
+++ b/src/Eccube/Rector/CodingStyle/AttributeArgumentsOrderRector.php
@@ -51,7 +51,7 @@ final class AttributeArgumentsOrderRector extends AbstractRector
      * 差し替え、置換後のクラスの正しいパラメータ順序（例: Template の $template）を使う。
      * 差し替えるのはリフレクション対象のみで、出力される Attribute 名ノードには手を加えない。
      *
-     * @var array<class-string, class-string>
+     * @var array<string, class-string>
      *
      * @see https://github.com/EC-CUBE/ec-cube/issues/6540
      */

--- a/src/Eccube/Rector/CodingStyle/AttributeArgumentsOrderRector.php
+++ b/src/Eccube/Rector/CodingStyle/AttributeArgumentsOrderRector.php
@@ -39,6 +39,30 @@ use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 final class AttributeArgumentsOrderRector extends AbstractRector
 {
     /**
+     * 非推奨アノテーションクラス → 新しい Attribute クラスのマッピング
+     *
+     * AnnotationToAttributeRector が Sensio FrameworkExtraBundle のアノテーションを
+     * Attribute に変換した直後、まだ use 文が Sensio クラスを指している段階で本ルールが走ると、
+     * リフレクションで Sensio 側のコンストラクタ第一パラメータ（例: Template の $data）を
+     * 読み取ってしまい、後段の RenameClassRector がクラスだけ置換しても誤った名前付き引数
+     * （例: #[Template(data: '...')]）が残る。
+     *
+     * これを避けるため、リフレクション対象のクラス名を「新しい Attribute クラス」へ事前に
+     * 差し替え、置換後のクラスの正しいパラメータ順序（例: Template の $template）を使う。
+     * 差し替えるのはリフレクション対象のみで、出力される Attribute 名ノードには手を加えない。
+     *
+     * @var array<class-string, class-string>
+     *
+     * @see https://github.com/EC-CUBE/ec-cube/issues/6540
+     */
+    private const DEPRECATED_CLASS_MAPPING = [
+        'Sensio\Bundle\FrameworkExtraBundle\Configuration\Template' => \Symfony\Bridge\Twig\Attribute\Template::class,
+        'Sensio\Bundle\FrameworkExtraBundle\Configuration\Cache' => \Symfony\Component\HttpKernel\Attribute\Cache::class,
+        'Sensio\Bundle\FrameworkExtraBundle\Configuration\IsGranted' => \Symfony\Component\Security\Http\Attribute\IsGranted::class,
+        'Sensio\Bundle\FrameworkExtraBundle\Configuration\Security' => \Symfony\Component\Security\Http\Attribute\IsGranted::class,
+    ];
+
+    /**
      * コンストラクタパラメータ順序のキャッシュ
      *
      * @var array<string, array<string, int>>
@@ -195,6 +219,10 @@ CODE_SAMPLE
      */
     private function getConstructorParameterOrder(string $className): array
     {
+        // 非推奨アノテーションクラスは新しい Attribute クラスへ差し替えてからリフレクションする
+        // (#6540: Sensio クラスの第一パラメータ名が残ってしまう問題への対策)
+        $className = self::DEPRECATED_CLASS_MAPPING[$className] ?? $className;
+
         // キャッシュをチェック
         if (isset($this->constructorParameterOrderCache[$className])) {
             return $this->constructorParameterOrderCache[$className];

--- a/src/Eccube/Service/TaxRuleService.php
+++ b/src/Eccube/Service/TaxRuleService.php
@@ -21,6 +21,7 @@ use Eccube\Entity\Product;
 use Eccube\Entity\ProductClass;
 use Eccube\Repository\BaseInfoRepository;
 use Eccube\Repository\TaxRuleRepository;
+use Symfony\Polyfill\Php84\Php84;
 
 class TaxRuleService
 {
@@ -128,14 +129,11 @@ class TaxRuleService
         static $diag = false;
         if (!$diag) {
             $diag = true;
-            $cls = 'Symfony\\Polyfill\\Php84\\Php84';
-            $fn = 'bcround';
-            $ref = new \ReflectionClass($cls);
+            $ref = new \ReflectionClass(Php84::class);
             fwrite(\STDERR, sprintf(
-                "[DIAG TaxRule] file=%s methods=%s global_bcround=%s\n",
+                "[DIAG TaxRule] file=%s methods=%s\n",
                 (string) $ref->getFileName(),
-                implode(',', array_map(static fn (\ReflectionMethod $m): string => $m->getName(), $ref->getMethods())),
-                function_exists($fn) ? (new \ReflectionFunction($fn))->getFileName().':'.(new \ReflectionFunction($fn))->getStartLine() : 'nofunc'
+                implode(',', array_map(static fn (\ReflectionMethod $m): string => $m->getName(), $ref->getMethods()))
             ));
         }
 

--- a/src/Eccube/Service/TaxRuleService.php
+++ b/src/Eccube/Service/TaxRuleService.php
@@ -21,7 +21,6 @@ use Eccube\Entity\Product;
 use Eccube\Entity\ProductClass;
 use Eccube\Repository\BaseInfoRepository;
 use Eccube\Repository\TaxRuleRepository;
-use Symfony\Polyfill\Php84\Php84;
 
 class TaxRuleService
 {
@@ -129,13 +128,14 @@ class TaxRuleService
         static $diag = false;
         if (!$diag) {
             $diag = true;
-            $ref = new \ReflectionClass(Php84::class);
+            $cls = 'Symfony\\Polyfill\\Php84\\Php84';
+            $fn = 'bcround';
+            $ref = new \ReflectionClass($cls);
             fwrite(\STDERR, sprintf(
-                "[DIAG TaxRule] Php84::bcround=%d file=%s methods=%s global_bcround=%s\n",
-                method_exists(Php84::class, 'bcround') ? 1 : 0,
+                "[DIAG TaxRule] file=%s methods=%s global_bcround=%s\n",
                 (string) $ref->getFileName(),
                 implode(',', array_map(static fn (\ReflectionMethod $m): string => $m->getName(), $ref->getMethods())),
-                function_exists('bcround') ? (new \ReflectionFunction('bcround'))->getFileName().':'.(new \ReflectionFunction('bcround'))->getStartLine() : 'nofunc'
+                function_exists($fn) ? (new \ReflectionFunction($fn))->getFileName().':'.(new \ReflectionFunction($fn))->getStartLine() : 'nofunc'
             ));
         }
 

--- a/src/Eccube/Service/TaxRuleService.php
+++ b/src/Eccube/Service/TaxRuleService.php
@@ -21,6 +21,7 @@ use Eccube\Entity\Product;
 use Eccube\Entity\ProductClass;
 use Eccube\Repository\BaseInfoRepository;
 use Eccube\Repository\TaxRuleRepository;
+use Symfony\Polyfill\Php84\Php84;
 
 class TaxRuleService
 {
@@ -125,6 +126,19 @@ class TaxRuleService
      */
     public static function roundByRoundingType(string $value, int $RoundingType): string
     {
+        static $diag = false;
+        if (!$diag) {
+            $diag = true;
+            $ref = new \ReflectionClass(Php84::class);
+            fwrite(\STDERR, sprintf(
+                "[DIAG TaxRule] Php84::bcround=%d file=%s methods=%s global_bcround=%s\n",
+                method_exists(Php84::class, 'bcround') ? 1 : 0,
+                (string) $ref->getFileName(),
+                implode(',', array_map(static fn (\ReflectionMethod $m): string => $m->getName(), $ref->getMethods())),
+                function_exists('bcround') ? (new \ReflectionFunction('bcround'))->getFileName().':'.(new \ReflectionFunction('bcround'))->getStartLine() : 'nofunc'
+            ));
+        }
+
         return match ($RoundingType) {
             // 四捨五入
             RoundingType::ROUND => bcround($value),

--- a/tests/Eccube/Tests/Rector/CodingStyle/AttributeArgumentsOrderRectorTest.php
+++ b/tests/Eccube/Tests/Rector/CodingStyle/AttributeArgumentsOrderRectorTest.php
@@ -1,0 +1,37 @@
+<?php
+
+/*
+ * This file is part of EC-CUBE
+ *
+ * Copyright(c) EC-CUBE CO.,LTD. All Rights Reserved.
+ *
+ * http://www.ec-cube.co.jp/
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Eccube\Tests\Rector\CodingStyle;
+
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+
+final class AttributeArgumentsOrderRectorTest extends AbstractRectorTestCase
+{
+    /**
+     * @dataProvider provideData
+     */
+    public function test(string $filePath): void
+    {
+        $this->doTestFile($filePath);
+    }
+
+    public static function provideData(): \Iterator
+    {
+        return self::yieldFilesFromDirectory(__DIR__.'/Fixture');
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__.'/config/configured_rule.php';
+    }
+}

--- a/tests/Eccube/Tests/Rector/CodingStyle/AttributeArgumentsOrderRectorTest.php
+++ b/tests/Eccube/Tests/Rector/CodingStyle/AttributeArgumentsOrderRectorTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * This file is part of EC-CUBE
  *
@@ -13,13 +15,12 @@
 
 namespace Eccube\Tests\Rector\CodingStyle;
 
+use PHPUnit\Framework\Attributes\DataProvider;
 use Rector\Testing\PHPUnit\AbstractRectorTestCase;
 
 final class AttributeArgumentsOrderRectorTest extends AbstractRectorTestCase
 {
-    /**
-     * @dataProvider provideData
-     */
+    #[DataProvider(methodName: 'provideData')]
     public function test(string $filePath): void
     {
         $this->doTestFile($filePath);

--- a/tests/Eccube/Tests/Rector/CodingStyle/Fixture/deprecated_template_attribute.php.inc
+++ b/tests/Eccube/Tests/Rector/CodingStyle/Fixture/deprecated_template_attribute.php.inc
@@ -1,0 +1,31 @@
+<?php
+
+namespace Eccube\Tests\Rector\CodingStyle\Fixture;
+
+use Sensio\Bundle\FrameworkExtraBundle\Configuration\Template;
+
+class DeprecatedTemplateAttribute
+{
+    #[Template('@admin/Content/cache.twig')]
+    public function index()
+    {
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Eccube\Tests\Rector\CodingStyle\Fixture;
+
+use Sensio\Bundle\FrameworkExtraBundle\Configuration\Template;
+
+class DeprecatedTemplateAttribute
+{
+    #[Template(template: '@admin/Content/cache.twig')]
+    public function index()
+    {
+    }
+}
+
+?>

--- a/tests/Eccube/Tests/Rector/CodingStyle/Fixture/route_attribute_order.php.inc
+++ b/tests/Eccube/Tests/Rector/CodingStyle/Fixture/route_attribute_order.php.inc
@@ -1,0 +1,31 @@
+<?php
+
+namespace Eccube\Tests\Rector\CodingStyle\Fixture;
+
+use Symfony\Component\Routing\Attribute\Route;
+
+class RouteAttributeOrder
+{
+    #[Route('/contact', requirements: ['id' => '\d+'], name: 'contact', methods: ['GET', 'POST'])]
+    public function contact()
+    {
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Eccube\Tests\Rector\CodingStyle\Fixture;
+
+use Symfony\Component\Routing\Attribute\Route;
+
+class RouteAttributeOrder
+{
+    #[Route(path: '/contact', name: 'contact', requirements: ['id' => '\d+'], methods: ['GET', 'POST'])]
+    public function contact()
+    {
+    }
+}
+
+?>

--- a/tests/Eccube/Tests/Rector/CodingStyle/config/configured_rule.php
+++ b/tests/Eccube/Tests/Rector/CodingStyle/config/configured_rule.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of EC-CUBE
+ *
+ * Copyright(c) EC-CUBE CO.,LTD. All Rights Reserved.
+ *
+ * http://www.ec-cube.co.jp/
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+use Eccube\Rector\CodingStyle\AttributeArgumentsOrderRector;
+use Rector\Config\RectorConfig;
+
+return RectorConfig::configure()
+    ->withRules([
+        AttributeArgumentsOrderRector::class,
+    ]);

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -12,14 +12,15 @@
  */
 
 use Symfony\Component\Dotenv\Dotenv;
+use Symfony\Polyfill\Php84\Php84;
 
 require dirname(__DIR__).'/vendor/autoload.php';
 
 // TEMP DIAGNOSTIC (bcround 調査)
 fwrite(STDERR, sprintf(
     "[DIAG bootstrap] Php84::bcround=%d file=%s global_bcround=%s bcround(2.5)=%s\n",
-    method_exists('Symfony\\Polyfill\\Php84\\Php84', 'bcround') ? 1 : 0,
-    (new ReflectionClass('Symfony\\Polyfill\\Php84\\Php84'))->getFileName(),
+    method_exists(Php84::class, 'bcround') ? 1 : 0,
+    (new ReflectionClass(Php84::class))->getFileName(),
     function_exists('bcround') ? (new ReflectionFunction('bcround'))->getFileName().':'.(new ReflectionFunction('bcround'))->getStartLine() : 'nofunc',
     function_exists('bcround') ? @bcround('2.5') : 'nofunc'
 ));

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -15,6 +15,15 @@ use Symfony\Component\Dotenv\Dotenv;
 
 require dirname(__DIR__).'/vendor/autoload.php';
 
+// TEMP DIAGNOSTIC (bcround 調査)
+fwrite(STDERR, sprintf(
+    "[DIAG bootstrap] Php84::bcround=%d file=%s global_bcround=%s bcround(2.5)=%s\n",
+    method_exists('Symfony\\Polyfill\\Php84\\Php84', 'bcround') ? 1 : 0,
+    (new ReflectionClass('Symfony\\Polyfill\\Php84\\Php84'))->getFileName(),
+    function_exists('bcround') ? (new ReflectionFunction('bcround'))->getFileName().':'.(new ReflectionFunction('bcround'))->getStartLine() : 'nofunc',
+    function_exists('bcround') ? @bcround('2.5') : 'nofunc'
+));
+
 if (file_exists(dirname(__DIR__).'/config/bootstrap.php')) {
     require dirname(__DIR__).'/config/bootstrap.php';
 } elseif (method_exists(Dotenv::class, 'bootEnv')) {


### PR DESCRIPTION
キャッシュ汚染か CI 環境(opcache 等)かを切り分けるため、composer キャッシュを完全無効化して fresh install で unit-test を検証する実験 PR。検証後クローズ。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 旧式のアノテーション/属性の新しい書き方への変換に対応し、テンプレート/ルート属性の引数順を名前付きで扱いやすく整えました。
* **Bug Fixes**
  * 非推奨クラス由来の引数不整合に起因する誤変換を防ぐよう改善しました。
* **Tests / CI**
  * 属性変換のテストと設定を追加し、CIでOPcache無効化や `bcround` 関連の診断ログ出力を行うよう変更しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->